### PR TITLE
Feat/mobile numpad opens

### DIFF
--- a/src/components/HouseholdForm/HouseholdForm.tsx
+++ b/src/components/HouseholdForm/HouseholdForm.tsx
@@ -825,8 +825,6 @@ const HouseholdForm: React.FC<HouseholdFormProps> = ({ householdData, updateHous
                     render={({ field: { onChange, onBlur, value, ref } }) => (
                       <TextField
                         id="outlined-number"
-                        // type="number" // This is causes the input to always have a 0 if empty
-                        inputMode="numeric"
                         InputLabelProps={{
                           shrink: true,
                         }}
@@ -879,6 +877,8 @@ const HouseholdForm: React.FC<HouseholdFormProps> = ({ householdData, updateHous
                             style: { textAlign: 'right' },
                             min: 0,
                             max: 1000,
+                            inputMode: "numeric",
+                            pattern: '[0-9]*',
                           }
                         }}
                         error={!!methods.formState.errors.solar?.size}
@@ -1045,11 +1045,9 @@ const HouseholdForm: React.FC<HouseholdFormProps> = ({ householdData, updateHous
                   <Controller
                     name="battery.capacity"
                     control={methods.control}
-                    render={({ field: { onChange, onBlur, value, ref } }) => (
+                    render={({ field: { onChange, ref } }) => (
                       <TextField
                         id="outlined-number"
-                        // type="number" // This is causes the input to always have a 0 if empty
-                        inputMode="numeric"
                         value={batteryCapacity ?? ''}
                         onChange={(e) => {
                           const numericValue = parseFloat(e.target.value);
@@ -1104,6 +1102,8 @@ const HouseholdForm: React.FC<HouseholdFormProps> = ({ householdData, updateHous
                             style: { textAlign: 'right' },
                             min: 0,
                             max: 1000,
+                            inputMode: "numeric",
+                            pattern: '[0-9]*',
                           }
                         }}
                         error={!!methods.formState.errors.battery?.capacity}


### PR DESCRIPTION
Mobile improvement: For number-only fields, number keypad opens up, not full keyboard