### PR TITLE
feat: show/hide replacement cost details

### DIFF
--- a/src/components/HouseholdSavings/HouseholdSavings.tsx
+++ b/src/components/HouseholdSavings/HouseholdSavings.tsx
@@ -203,6 +203,7 @@ const HouseholdSavings: React.FC<SavingsProps> = ({ results, loadingData, applia
                 <ResultBox
                     label="Replacement Cost"
                     heading={upfrontCostTotal}
+                    subheading="for new appliances, solar, and/or battery"
                     bulletPoints={[
                         { label: 'House heating', value: Math.round((results?.upfrontCost?.spaceHeating || 0) / 100) * 100 },
                         { label: 'Water heating', value: Math.round((results?.upfrontCost?.waterHeating || 0) / 100) * 100 },
@@ -215,12 +216,12 @@ const HouseholdSavings: React.FC<SavingsProps> = ({ results, loadingData, applia
                         <>
                             <Typography variant="h2"
                                 sx={{
-                                    margin: '0.8rem 0 0.2rem 0'
+                                    margin: '1.5rem 0 0.2rem 0'
                                 }}>
                                 + {vehicleCostStr}
                             </Typography>
                             <Typography variant="body2">
-                                <span style={{ fontWeight: '600' }}>to buy {numEVsToBuy} new EVs.</span> New mid-range EVs cost $30k-$70k each, depending on the model. Secondhand EVs start at ~$3k.&nbsp;
+                                <span style={{ fontWeight: '600' }}>for {numEVsToBuy} new EVs.</span> New mid-range EVs cost $30k-$70k each, depending on the model. Secondhand EVs start at ~$3k.&nbsp;
                                 <Link
                                     href={electricVehicleURL}
                                     target="_blank"

--- a/src/components/HouseholdSavings/ResultBox.tsx
+++ b/src/components/HouseholdSavings/ResultBox.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Box, Tooltip, Typography, useTheme } from '@mui/material';
 import { formatNZD } from 'src/shared/utils/formatters';
 
@@ -10,6 +10,7 @@ interface BulletPoint {
 interface ResultBoxState { 
     label: string;
     heading: string | number;
+    subheading?: string | number;
     bulletPoints?: BulletPoint[];
     paragraph?: string;
     linkText?: string;
@@ -18,8 +19,9 @@ interface ResultBoxState {
 }
 
   
-const ResultBox: React.FC<ResultBoxState> = ({ label, heading, bulletPoints, paragraph, children }) => {
+const ResultBox: React.FC<ResultBoxState> = ({ label, heading, subheading, bulletPoints, paragraph, children }) => {
     const theme = useTheme();
+    const [isExpanded, setIsExpanded] = useState(false);
     
 
     return (
@@ -37,35 +39,56 @@ const ResultBox: React.FC<ResultBoxState> = ({ label, heading, bulletPoints, par
                 }}>
                 {heading}
             </Typography>
-            {bulletPoints && (
-                <Box
-                    component="ul"
-                    sx={{
-                        listStyleType: 'disc',
-                        paddingLeft: '1.5rem',
-                        marginBottom: '1.5rem'
-                    }}
-                >
-                    {bulletPoints.map((point, i) => (
-                        <Typography
-                            key={i}
-                            component="li"
-                            variant="body2"
-                            sx={{
-                                lineHeight: '1.5rem' 
-                            }}
-                            >
-                            <span style={{ 
-                                fontWeight: 'bold',
-                                }}>
-                                {point.label}: 
-                            </span>
-
-                            {typeof point.value === "string" ? point.value : formatNZD(point.value, 0)}
-
+            {subheading && 
+                <Typography variant="body2">
+                    <span style={{ fontWeight: '600' }}>{subheading}&nbsp;</span>
+                    {bulletPoints && <Typography
+                        variant="body2"
+                        sx={{
+                            cursor: 'pointer',
+                            textDecorationLine: 'underline',
+                            display: 'inline-block'
+                        }}
+                        onClick={() => setIsExpanded(!isExpanded)}>
+                            {isExpanded ? '(hide details)' : '(show details)'}
                         </Typography>
-                    ))}
-                </Box>
+                    }
+                </Typography>
+            }
+            {bulletPoints && isExpanded && (
+                <>    
+                    <Box
+                        component="ul"
+                        sx={{
+                            listStyleType: 'disc',
+                            paddingLeft: '1.5rem',
+                            marginBottom: '0.8rem'
+                        }}
+                    >
+                        {bulletPoints.map((point, i) => (
+                            <Typography
+                                key={i}
+                                component="li"
+                                variant="body2"
+                                sx={{
+                                    lineHeight: '1.5rem' 
+                                }}
+                                >
+                                <span style={{ 
+                                    fontWeight: 'bold',
+                                    }}>
+                                    {point.label}: 
+                                </span>
+
+                                {typeof point.value === "string" ? point.value : formatNZD(point.value, 0)}
+
+                            </Typography>
+                        ))}
+                    </Box>
+                    <Typography variant="body2">
+                        This shows only the cost of electric alternatives, without comparing the cost of replacing with fossil fuel models as machines break. In reality, the cost of electrification is lower; it is just the difference between electric and fossil fuel counterparts.
+                    </Typography>
+                </>
             )}
 
             {paragraph && (


### PR DESCRIPTION
And add a note about how the actual cost difference with fossil fuels is less than this, and the difference is a more realistic view of cost given that they're going to have to replace it with something, whether fossil fuels or electric, but we're not showing it here (yet)