### PR TITLE
fix: mobile savings drawer stays at full height

### DIFF
--- a/src/components/MobileSavingsDrawer/MobileSavingsDrawer.tsx
+++ b/src/components/MobileSavingsDrawer/MobileSavingsDrawer.tsx
@@ -91,7 +91,7 @@ const MobileSavingsDrawer = (savings: SavingsDrawerProps) => {
                         alignItems: 'center',
                         gap: '0.25rem',
                         cursor: 'pointer',
-                        // pointerEvents: 'auto',
+                        pointerEvents: 'auto',
                     }}>
                     {drawerOpen ? (
                         <ChevronUp />


### PR DESCRIPTION
Mobile bug fix: on pulling the drawer and pulling it slightly down, the top text gets cut off. Now resolved.