### PR TITLE
Correct display name for Manawatū-Whanganui

### DIFF
--- a/src/components/HouseholdForm/data/householdForm.text.ts
+++ b/src/components/HouseholdForm/data/householdForm.text.ts
@@ -29,7 +29,7 @@ export const locationMapping: Record<LocationEnum, string> = {
   [LocationEnum.Gisborne]: "Gisborne / Tairāwhiti",
   [LocationEnum.HawkesBay]: "Hawke's Bay / Te Matau-a-Māui",
   [LocationEnum.Taranaki]: "Taranaki",
-  [LocationEnum.ManawatuWanganui]: "Manawatu-Wanganui",
+  [LocationEnum.ManawatuWanganui]: "Manawatū-Whanganui",
   [LocationEnum.Wellington]: "Wellington / Te Whanganui a Tara",
   [LocationEnum.Tasman]: "Tasman / Te Tai o Aorere",
   [LocationEnum.Nelson]: "Nelson / Whakatū",


### PR DESCRIPTION
The region name was officially changed from Manawatu-Wanganui to Manawatū-Whanganui in 2019. This corrects the display name.